### PR TITLE
Fixed typos and updated cmd for required tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Feel free to join our [discord channel](https://discord.gg/rE2nHVAKvn) and ask a
 
 ## Connecting the debugger
 
-When connecting the debugger ensrue that at least SWDIO, SWDCLK and GND are connected. Do *not* under any circumstances connect 3.3V to the VDD connection. If your debug probe (for example ST-Link clones) does not have a VTREF connector, just leave VDD unconnected. Connecting 3.3V to VDD will likely destroy your SPI flash.
+When connecting the debugger ensure that at least SWDIO, SWDCLK and GND are connected. Do *not* under any circumstances connect 3.3V to the VDD connection. If your debug probe (for example ST-Link clones) does not have a VTREF connector, just leave VDD unconnected. Connecting 3.3V to VDD will likely destroy your SPI flash.
 
 
 ### Ubuntu setup
@@ -49,7 +49,7 @@ OPENOCD="/opt/openocd-git/bin/openocd" ; ./1_sanity_check.sh
 OPENOCD="/opt/openocd-git/bin/openocd" ; ./2_....
 ```
 
-Finally you could just hardwire some variables in 'config.sh'
+Finally, you could just hardwire some variables in 'config.sh'
 
 ### Mac Setup
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ When connecting the debugger ensrue that at least SWDIO, SWDCLK and GND are conn
 Install the required tools:
 
 ```
-sudo apt-get install gcc-arm-none-eabi binutils-arm-none-eabi openocd python3
+sudo apt-get install gcc-arm-none-eabi binutils-arm-none-eabi openocd python3 libftdi1
 ```
 
 Note: The version of openocd included in Ubuntu 20.04 (0.10.0) does not include functionality that is needed by these scripts. A build from the unreleased master branch is needed. Please install a newer version either by building it yourself, or by installing a prebuilt package, e.g. from [this nightly build](https://github.com/kbeckmann/ubuntu-openocd-git-builder), using [xPack](https://xpack.github.io/openocd/) or similar.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ When connecting the debugger ensrue that at least SWDIO, SWDCLK and GND are conn
 Install the required tools:
 
 ```
-sudo apt-get install gcc-arm-none-eabi binutils-arm-none-eabi openocd python3 libftdi1
+sudo apt-get install gcc-arm-none-eabi binutils-arm-none-eabi python3 libftdi1
 ```
 
 Note: The version of openocd included in Ubuntu 20.04 (0.10.0) does not include functionality that is needed by these scripts. A build from the unreleased master branch is needed. Please install a newer version either by building it yourself, or by installing a prebuilt package, e.g. from [this nightly build](https://github.com/kbeckmann/ubuntu-openocd-git-builder), using [xPack](https://xpack.github.io/openocd/) or similar.


### PR DESCRIPTION
I removed `openocd` from the `apt-get` line as people are going to install it and the nightly and get conflicts as a result, which can be very confusing. I also added `libftdi1` to the line because it was not on my machine and was listed as required by openocd, so others may have the same issue.