### PR TITLE
Added support for large SPI flashes when restoring.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ Step 4 will cause a mass erase, and leave your device empty. To restore it, run 
 
 Step 5 should succeed, if it doesn't: Try to run the script while holding down the power button of the Game & Watch. Try power-cycling the target in between attempts.
 
+If you replaced the SPI flash with a bigger size then also try :
+
+```
+LARGE_FLASH=1 ./5_restore.sh <stlink or jlink or rpi> <mario or zelda>
+```
+
 ### Getting help and contributing
 
 Feel free to join our [discord channel](https://discord.gg/rE2nHVAKvn) and ask any support questions in *#game-and-watch-support*.

--- a/openocd/stm32h7x_spiflash.cfg
+++ b/openocd/stm32h7x_spiflash.cfg
@@ -63,8 +63,14 @@ proc hxa-001_qspi_init { } {
 	sleep 20								;# wait for the flash to come out of reset
 
 	mmw 0x52005000 0x30000000 0x00000001	;# OCTOSPI_CR |= FMODE=0x3, &= ~EN
-	# OCTOSPI1: memory-mapped 1-line read mode with 3-byte addresses
-	mww 0x52005100 0x01002101				;# OCTOSPI_CCR: DMODE=0x1, ABMODE=0x0, ADSIZE=0x2, ADMODE=0x1, ISIZE=0x0, IMODE=0x1
+
+	if { [env LARGE_FLASH] == 0 } {
+		# OCTOSPI1: memory-mapped 1-line read mode with 3-byte addresses
+		mww 0x52005100 0x01002101				;# OCTOSPI_CCR: DMODE=0x1, ABMODE=0x0, ADSIZE=0x2, ADMODE=0x1, ISIZE=0x0, IMODE=0x1
+	} else {
+		# OCTOSPI1: memory-mapped 1-line read mode with 4-byte addresses
+		mww 0x52005100 0x01003101				;# OCTOSPI_CCR: DMODE=0x1, ABMODE=0x0, ADSIZE=0x3, ADMODE=0x1, ISIZE=0x0, IMODE=0x1
+	}
 	mww 0x52005110 0x00000003				;# OCTOSPI_IR: INSTR=READ
 	mmw 0x52005000 0x00000001 0x00000000	;# OCTOSPI_CR |= EN
 

--- a/openocd/stm32h7x_spiflash.cfg
+++ b/openocd/stm32h7x_spiflash.cfg
@@ -64,12 +64,12 @@ proc hxa-001_qspi_init { } {
 
 	mmw 0x52005000 0x30000000 0x00000001	;# OCTOSPI_CR |= FMODE=0x3, &= ~EN
 
-	if { [env LARGE_FLASH] == 0 } {
-		# OCTOSPI1: memory-mapped 1-line read mode with 3-byte addresses
-		mww 0x52005100 0x01002101				;# OCTOSPI_CCR: DMODE=0x1, ABMODE=0x0, ADSIZE=0x2, ADMODE=0x1, ISIZE=0x0, IMODE=0x1
-	} else {
+	if { [info exists ::env(LARGE_FLASH)] == 1 && [env LARGE_FLASH]  == 1 } {
 		# OCTOSPI1: memory-mapped 1-line read mode with 4-byte addresses
 		mww 0x52005100 0x01003101				;# OCTOSPI_CCR: DMODE=0x1, ABMODE=0x0, ADSIZE=0x3, ADMODE=0x1, ISIZE=0x0, IMODE=0x1
+	} else {
+		# OCTOSPI1: memory-mapped 1-line read mode with 3-byte addresses
+		mww 0x52005100 0x01002101				;# OCTOSPI_CCR: DMODE=0x1, ABMODE=0x0, ADSIZE=0x2, ADMODE=0x1, ISIZE=0x0, IMODE=0x1
 	}
 	mww 0x52005110 0x00000003				;# OCTOSPI_IR: INSTR=READ
 	mmw 0x52005000 0x00000001 0x00000000	;# OCTOSPI_CR |= EN


### PR DESCRIPTION
Added a device reset upon restore success.
Updated README.md to reflect the changes.

The changes makes it possible to restore the device to a stock configuration after the SPI flash has been replaced with a larger size (that uses 4 byte addresses).