### PR TITLE
Fix Markdown link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ You can use a Flipper Zero and its DAP Link app. As of firmware version 0.89 and
 
 <details>
 <summary>How to install the DAP Link app</summary>
+
 [Pair](https://docs.flipper.net/mobile-app) the companion mobile app with your Flipper Zero. In the mobile app, go to the app directory on the "Hub" tab. Find the "GPIO" category, browse for the "DAP Link" app inside it, and tap "Install".
 </details>
 


### PR DESCRIPTION
The Markdown link in #33 was not rendered correctly in the section about installing the DAP Link app on a Flipper Zero. Adding a newline between the `<summary>` and the expanded text fixes this.

Verified by checking the before and after versions of the formatted README in this PR. GitHub shows a preview of both.

Together with #33, this closes #31 and #19.