### PR TITLE
Change shasum to sha1sum

### DIFF
--- a/1_sanity_check.sh
+++ b/1_sanity_check.sh
@@ -25,4 +25,10 @@ if ! arm-none-eabi-objdump -v >/dev/null 2>&1; then
     exit 1
 fi
 
+if ! sha1sum --version >/dev/null 2>&1; then
+    echo "Could not find sha1sum. Is your environment set up correctly?"
+    echo " It may need to be installed separately."
+    exit 1
+fi
+
 echo "Looks good!"

--- a/2_backup_flash.sh
+++ b/2_backup_flash.sh
@@ -21,7 +21,7 @@ if ! ${OPENOCD} \
 fi
 
 echo "Validating ITCM dump..."
-if ! shasum --check shasums/itcm_backup_${TARGET}.bin.sha1 >/dev/null 2>&1; then
+if ! sha1sum --check shasums/itcm_backup_${TARGET}.bin.sha1 >/dev/null 2>&1; then
     echo "Failed to correctly dump ITCM. Restart Game & Watch and try again."
     exit 1
 fi
@@ -37,7 +37,7 @@ if ! dd if=backups/flash_backup_${TARGET}.bin of=backups/flash_backup_checksumme
 fi
 
 echo "Validating checksum..."
-if ! shasum --check shasums/flash_backup_checksummed_${TARGET}.bin.sha1 >/dev/null 2>&1; then
+if ! sha1sum --check shasums/flash_backup_checksummed_${TARGET}.bin.sha1 >/dev/null 2>&1; then
     echo "Failed to verify checksum of the external flash. Try again."
     exit 1
 fi

--- a/3_backup_internal_flash.sh
+++ b/3_backup_internal_flash.sh
@@ -15,7 +15,7 @@ if ! dd if=backups/flash_backup_${TARGET}.bin of=backups/flash_backup_checksumme
     exit 1
 fi
 
-if ! shasum --check shasums/flash_backup_checksummed_${TARGET}.bin.sha1 >/dev/null 2>&1; then
+if ! sha1sum --check shasums/flash_backup_checksummed_${TARGET}.bin.sha1 >/dev/null 2>&1; then
     echo "*** External flash backup does not verify correctly ***"
     echo "Please run ./2_backup_flash.sh again"
     rm backups/flash_backup_checksummed.bin
@@ -23,7 +23,7 @@ if ! shasum --check shasums/flash_backup_checksummed_${TARGET}.bin.sha1 >/dev/nu
 fi
 
 echo "Validating ITCM dump..."
-if ! shasum --check shasums/itcm_backup_${TARGET}.bin.sha1 >/dev/null 2>&1; then
+if ! sha1sum --check shasums/itcm_backup_${TARGET}.bin.sha1 >/dev/null 2>&1; then
     echo "*** ITCM dump does not verify correctly ***"
     echo "Please run ./2_backup_flash.sh again"
     exit 1
@@ -83,7 +83,7 @@ if ! ${OPENOCD} -f "openocd/interface_${ADAPTER}.cfg" \
 fi
 
 echo "Verifying internal flash backup..."
-if ! shasum --check shasums/internal_flash_backup_${TARGET}.bin.sha1 >/dev/null 2>&1; then
+if ! sha1sum --check shasums/internal_flash_backup_${TARGET}.bin.sha1 >/dev/null 2>&1; then
     echo "The backup of the internal flash failed. Please try again."
     exit 1
 fi

--- a/4_unlock_device.sh
+++ b/4_unlock_device.sh
@@ -12,7 +12,7 @@ then
 fi
 
 echo "Validating internal flash backup before proceeding..."
-if ! shasum --check shasums/internal_flash_backup_${TARGET}.bin.sha1 >/dev/null 2>&1; then
+if ! sha1sum --check shasums/internal_flash_backup_${TARGET}.bin.sha1 >/dev/null 2>&1; then
     echo "Backup is not valid. Aborting."
     exit 1
 fi

--- a/scripts/rdp1.sh
+++ b/scripts/rdp1.sh
@@ -11,7 +11,7 @@ then
 fi
 
 echo "Validating internal flash backup before proceeding..."
-if ! shasum --check shasums/internal_flash_backup_$TARGET.bin.sha1 >/dev/null 2>&1; then
+if ! sha1sum --check shasums/internal_flash_backup_$TARGET.bin.sha1 >/dev/null 2>&1; then
     echo "Backup is not valid. Aborting."
     exit 1
 fi


### PR DESCRIPTION
`shasum` doesn't seem to be available on any of my systems, but `sha1sum` seems to be available everywhere, including Windows.  
As a result, this also makes Windows work out of the box, without any further changes (provided that openocd is available in PATH, and the user has msys installed with bash and sha1sum).